### PR TITLE
Added responsive leaderboard page with search and sorting

### DIFF
--- a/Pages/leaderboard.html
+++ b/Pages/leaderboard.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spurdle</title>
+
+    <link rel="stylesheet" href="style.css" />
+
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="../Scripts/tailwind-config.js"></script>
+    <script src="../Scripts/leaderboard.js" defer></script>
+  </head>
+
+  <body class="bg-background-black text-white">
+    <main class="min-h-screen px-4 py-6 md:px-8 lg:px-12">
+      <div class="mx-auto max-w-6xl">
+        <header class="rounded-[28px] border border-white/10 bg-black/40 p-4 shadow-[0_0_30px_rgba(0,0,0,0.25)] md:p-6">
+          <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <a href="welcome.html" class="inline-block">
+              <h1 class="font-syne text-5xl leading-none md:text-6xl">
+                <span class="text-white">spu</span><span class="text-neon-green">rdle</span>
+              </h1>
+            </a>
+
+            <nav class="flex flex-wrap items-center gap-3 text-sm font-semibold md:gap-6">
+              <a href="leaderboard.html" class="text-neon-green">Leaderboard</a>
+              <a href="#" class="transition hover:text-neon-green">My Account</a>
+              <a
+                href="#"
+                class="rounded-xl bg-neon-green px-4 py-2 text-black transition hover:scale-105"
+              >
+                Play now
+              </a>
+            </nav>
+          </div>
+
+          <div class="mt-8 grid gap-4 lg:grid-cols-[1.45fr_1fr]">
+            <div>
+              <p class="text-sm uppercase tracking-[0.35em] text-neon-green/80">spurdle rankings</p>
+              <h2 class="mt-3 text-4xl font-bold md:text-5xl">Leaderboard</h2>
+              <p class="mt-4 max-w-2xl text-sm leading-6 text-white/70 md:text-base">
+                Compare points, streaks and accuracy across the Spurdle community.
+                Search for a player and sort the rankings below.
+              </p>
+            </div>
+
+            <div class="grid grid-cols-2 gap-3">
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.2em] text-white/50">Players shown</p>
+                <p id="totalPlayersStat" class="mt-3 text-2xl font-bold">0</p>
+              </div>
+
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.2em] text-white/50">Top score</p>
+                <p id="topScoreStat" class="mt-3 text-2xl font-bold">0</p>
+              </div>
+
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.2em] text-white/50">Best streak</p>
+                <p id="bestStreakStat" class="mt-3 text-2xl font-bold">0</p>
+              </div>
+
+              <div class="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <p class="text-xs uppercase tracking-[0.2em] text-white/50">Avg accuracy</p>
+                <p id="avgAccuracyStat" class="mt-3 text-2xl font-bold">0%</p>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <section id="podiumSection" class="mt-6 grid gap-4 md:grid-cols-3"></section>
+
+        <section class="mt-6 rounded-[28px] border border-white/10 bg-[#131318] p-4 md:p-6">
+          <div class="flex flex-col gap-4 xl:flex-row xl:items-center xl:justify-between">
+            <div>
+              <h3 class="text-xl font-bold md:text-2xl">Player Rankings</h3>
+              <p class="mt-1 text-sm text-white/55">Search and sort the current leaderboard.</p>
+            </div>
+
+            <div class="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <input
+                id="searchInput"
+                type="text"
+                placeholder="Search player"
+                class="rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white outline-none placeholder:text-white/35 focus:border-neon-green"
+              />
+
+              <select
+                id="sortSelect"
+                class="rounded-xl border border-white/10 bg-black/30 px-4 py-2 text-sm text-white outline-none focus:border-neon-green"
+              >
+                <option value="points">Sort by points</option>
+                <option value="streak">Sort by streak</option>
+                <option value="accuracy">Sort by accuracy</option>
+              </select>
+            </div>
+          </div>
+
+          <div id="playerDetail" class="mt-4 rounded-2xl border border-neon-green/20 bg-neon-green/5 p-4 md:p-5"></div>
+
+          <div class="mt-5 hidden overflow-x-auto md:block">
+            <table class="w-full min-w-[850px] border-separate border-spacing-y-2 text-left">
+              <thead>
+                <tr class="text-sm uppercase tracking-[0.2em] text-white/45">
+                  <th class="px-4 py-2">Rank</th>
+                  <th class="px-4 py-2">Player</th>
+                  <th class="px-4 py-2">Points</th>
+                  <th class="px-4 py-2">Streak</th>
+                  <th class="px-4 py-2">Accuracy</th>
+                  <th class="px-4 py-2">Games</th>
+                  <th class="px-4 py-2">Avg hints</th>
+                </tr>
+              </thead>
+              <tbody id="leaderboardTableBody"></tbody>
+            </table>
+          </div>
+
+          <div id="leaderboardCards" class="mt-5 grid gap-3 md:hidden"></div>
+        </section>
+      </div>
+    </main>
+  </body>
+</html>

--- a/Scripts/leaderboard.js
+++ b/Scripts/leaderboard.js
@@ -47,6 +47,16 @@ function getVisiblePlayers() {
   return filteredPlayers;
 }
 
+function getGlobalTopPlayers() {
+  const globalPlayers = [...players];
+
+  globalPlayers.sort(function (a, b) {
+    return b.points - a.points;
+  });
+
+  return globalPlayers;
+}
+
 function updateStats(playerList) {
   if (playerList.length === 0) {
     totalPlayersStat.textContent = "0";
@@ -148,9 +158,10 @@ function updateCards(playerList) {
 
 function renderLeaderboard() {
   const visiblePlayers = getVisiblePlayers();
+  const globalTopPlayers = getGlobalTopPlayers();
 
   updateStats(visiblePlayers);
-  updatePodium(visiblePlayers);
+  updatePodium(globalTopPlayers);
   updatePlayerDetail(visiblePlayers);
   updateTable(visiblePlayers);
   updateCards(visiblePlayers);

--- a/Scripts/leaderboard.js
+++ b/Scripts/leaderboard.js
@@ -1,0 +1,168 @@
+const players = [
+  { name: "John", points: 432532, streak: 1923, accuracy: 96, games: 184, avgHints: 1.3 },
+  { name: "Nathan", points: 320000, streak: 841, accuracy: 91, games: 167, avgHints: 1.8 },
+  { name: "Mohammad", points: 280000, streak: 522, accuracy: 89, games: 152, avgHints: 2.0 },
+  { name: "Dhruv", points: 250000, streak: 411, accuracy: 85, games: 141, avgHints: 2.2 },
+  { name: "Surtaj", points: 98450, streak: 48, accuracy: 79, games: 64, avgHints: 2.7 }
+];
+
+const totalPlayersStat = document.getElementById("totalPlayersStat");
+const topScoreStat = document.getElementById("topScoreStat");
+const bestStreakStat = document.getElementById("bestStreakStat");
+const avgAccuracyStat = document.getElementById("avgAccuracyStat");
+
+const podiumSection = document.getElementById("podiumSection");
+const tableBody = document.getElementById("leaderboardTableBody");
+const cardsContainer = document.getElementById("leaderboardCards");
+const playerDetail = document.getElementById("playerDetail");
+
+const searchInput = document.getElementById("searchInput");
+const sortSelect = document.getElementById("sortSelect");
+
+let currentSort = "points";
+
+function formatNumber(number) {
+  return number.toLocaleString();
+}
+
+function getVisiblePlayers() {
+  const searchText = searchInput.value.toLowerCase();
+
+  let filteredPlayers = players.filter(function (player) {
+    return player.name.toLowerCase().includes(searchText);
+  });
+
+  filteredPlayers.sort(function (a, b) {
+    if (currentSort === "streak") {
+      return b.streak - a.streak;
+    }
+
+    if (currentSort === "accuracy") {
+      return b.accuracy - a.accuracy;
+    }
+
+    return b.points - a.points;
+  });
+
+  return filteredPlayers;
+}
+
+function updateStats(playerList) {
+  if (playerList.length === 0) {
+    totalPlayersStat.textContent = "0";
+    topScoreStat.textContent = "0";
+    bestStreakStat.textContent = "0";
+    avgAccuracyStat.textContent = "0%";
+    return;
+  }
+
+  totalPlayersStat.textContent = playerList.length;
+  topScoreStat.textContent = formatNumber(playerList[0].points);
+
+  let maxStreak = Math.max(...playerList.map(player => player.streak));
+  bestStreakStat.textContent = formatNumber(maxStreak);
+
+  let totalAccuracy = 0;
+  for (let player of playerList) {
+    totalAccuracy += player.accuracy;
+  }
+
+  let averageAccuracy = Math.round(totalAccuracy / playerList.length);
+  avgAccuracyStat.textContent = averageAccuracy + "%";
+}
+
+function updatePodium(playerList) {
+  const topThree = playerList.slice(0, 3);
+  podiumSection.innerHTML = "";
+
+  topThree.forEach(function (player, index) {
+    const card = document.createElement("div");
+    card.className = "rounded-[24px] border border-white/10 bg-white/5 p-5";
+
+    card.innerHTML = `
+      <p class="text-xs uppercase tracking-[0.22em] text-white/45">Top ${index + 1}</p>
+      <h3 class="mt-3 text-2xl font-bold">${player.name}</h3>
+      <p class="mt-2 text-neon-green font-semibold">${formatNumber(player.points)} points</p>
+      <p class="mt-1 text-sm text-white/60">${player.streak} day streak</p>
+    `;
+
+    podiumSection.appendChild(card);
+  });
+}
+
+function updatePlayerDetail(playerList) {
+  if (playerList.length === 0) {
+    playerDetail.innerHTML = `<p class="text-sm text-white/60">No players found.</p>`;
+    return;
+  }
+
+  const topPlayer = playerList[0];
+
+  playerDetail.innerHTML = `
+    <p class="text-xs uppercase tracking-[0.25em] text-neon-green/80">Current top player</p>
+    <h3 class="mt-3 text-2xl font-bold">${topPlayer.name}</h3>
+    <p class="mt-2 text-white/70">
+      ${formatNumber(topPlayer.points)} points · ${topPlayer.streak} streak · ${topPlayer.accuracy}% accuracy
+    </p>
+  `;
+}
+
+function updateTable(playerList) {
+  tableBody.innerHTML = "";
+
+  playerList.forEach(function (player, index) {
+    const row = document.createElement("tr");
+    row.className = "bg-white/5 hover:bg-white/10 transition";
+
+    row.innerHTML = `
+      <td class="rounded-l-2xl px-4 py-4 font-bold">${index + 1}</td>
+      <td class="px-4 py-4 font-semibold">${player.name}</td>
+      <td class="px-4 py-4">${formatNumber(player.points)}</td>
+      <td class="px-4 py-4">${player.streak}</td>
+      <td class="px-4 py-4">${player.accuracy}%</td>
+      <td class="px-4 py-4">${player.games}</td>
+      <td class="rounded-r-2xl px-4 py-4">${player.avgHints}</td>
+    `;
+
+    tableBody.appendChild(row);
+  });
+}
+
+function updateCards(playerList) {
+  cardsContainer.innerHTML = "";
+
+  playerList.forEach(function (player, index) {
+    const card = document.createElement("div");
+    card.className = "rounded-2xl border border-white/10 bg-white/5 p-4";
+
+    card.innerHTML = `
+      <p class="text-xs uppercase tracking-[0.2em] text-white/45">#${index + 1}</p>
+      <h3 class="mt-2 text-xl font-bold">${player.name}</h3>
+      <p class="mt-2 text-neon-green font-semibold">${formatNumber(player.points)} points</p>
+      <p class="mt-1 text-sm text-white/60">${player.streak} streak · ${player.accuracy}% accuracy</p>
+    `;
+
+    cardsContainer.appendChild(card);
+  });
+}
+
+function renderLeaderboard() {
+  const visiblePlayers = getVisiblePlayers();
+
+  updateStats(visiblePlayers);
+  updatePodium(visiblePlayers);
+  updatePlayerDetail(visiblePlayers);
+  updateTable(visiblePlayers);
+  updateCards(visiblePlayers);
+}
+
+searchInput.addEventListener("input", function () {
+  renderLeaderboard();
+});
+
+sortSelect.addEventListener("change", function () {
+  currentSort = sortSelect.value;
+  renderLeaderboard();
+});
+
+renderLeaderboard();


### PR DESCRIPTION
_"This PR adds the leaderboard page for Spurdle.

The page includes the main leaderboard layout, player stat cards, search by player name, and sorting by points, streaks, and accuracy. I also separated the JavaScript into its own file so the functionality is easier to manage and build on later.

I made this in a separate branch so it could be reviewed cleanly without affecting main straight away. Once reviewed, it should be merged into main so the leaderboard becomes part of the main working version of the project and can be used together with the rest of the site."_

This is a copy of the past pull request which was accidentally merged into main without review.