### PR TITLE
Fix leaderboard navigation links

### DIFF
--- a/Pages/leaderboard.html
+++ b/Pages/leaderboard.html
@@ -24,15 +24,15 @@
             </a>
 
             <nav class="flex flex-wrap items-center gap-3 text-sm font-semibold md:gap-6">
-              <a href="leaderboard.html" class="text-neon-green">Leaderboard</a>
-              <a href="#" class="transition hover:text-neon-green">My Account</a>
-              <a
-                href="#"
-                class="rounded-xl bg-neon-green px-4 py-2 text-black transition hover:scale-105"
-              >
-                Play now
-              </a>
-            </nav>
+  <span class="text-neon-green">Leaderboard</span>
+  <a href="sign-in.html" class="transition hover:text-neon-green">Sign in</a>
+  <a
+    href="main-game.html"
+    class="rounded-xl bg-neon-green px-4 py-2 text-black transition hover:scale-105"
+  >
+    Play now
+  </a>
+</nav>
           </div>
 
           <div class="mt-8 grid gap-4 lg:grid-cols-[1.45fr_1fr]">


### PR DESCRIPTION
This PR cleans up the navigation on the leaderboard page.

Changes made:
- kept the Spurdle logo linked to welcome.html
- changed the current Leaderboard nav item to a non-clickable active label
- replaced the placeholder account link with a Sign in link to sign-in.html
- updated the Play now button to link to main-game.html