### PR TITLE
feature/testing-single-album-hint

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -354,6 +354,36 @@ def song_details():
         "value": session.get('random_song_details', {}).get(argument)
     })
 
+@bp.route('/api/album-track-count')
+@login_required
+def album_track_count():
+    collection_id = request.args.get('collection_id')
+
+    if not collection_id:
+        return jsonify({"tracCount"})
+    
+    try:
+        response = requests.get(
+            "https://itunes.apple.com/lookup",
+            params={
+                "id": collection_id,
+                "entity": "song"
+            },
+            timeout=10
+        )
+
+        results = response.json().get("results", [])
+    
+    except (requests.RequestException, ValueError):
+        return jsonify({"trackCount": 0})
+    
+    track_count = 0
+
+    for item in results:
+        if item.get("wrapperType") == "track":
+            track_count += 1
+    
+    return jsonify({"trackCount": track_count})
 
 @bp.route('/api/artist-image')
 def artist_image():

--- a/app/static/itunesAPIconfig.js
+++ b/app/static/itunesAPIconfig.js
@@ -95,6 +95,22 @@ function setAlbumNAmeHint(albumName) {
     setTextIfElementExists('album-name', albumName || "Unknown album")
 }
 
+async function getAlbumTrackCount(collectionID) {
+    if (!collectionID) {
+        return 0;
+    }
+
+    try {
+        const response = await fetch ('/api/album-track-count?collection_id=${collectionID}');
+        const data = await response.json();
+
+        return data.trackCount || 0;
+    } catch (error) {
+        console.error("Could not get album track count", error);
+        return 0;
+    }
+}
+
 async function GetRandomSong() {
     const res = await fetch('/api/random-song?' + getArtistParams());
     const songDeets = await res.json();

--- a/app/static/itunesAPIconfig.js
+++ b/app/static/itunesAPIconfig.js
@@ -114,6 +114,8 @@ async function getAlbumTrackCount(collectionID) {
 async function GetRandomSong() {
     const res = await fetch('/api/random-song?' + getArtistParams());
     const songDeets = await res.json();
+    const collectionID = songDeets.collectionID
+    const trackCount = await getAlbumTrackCount(collectionID);
 
     if (songDeets.error) {
         console.error(songDeets.error);
@@ -129,7 +131,11 @@ async function GetRandomSong() {
     ]);
 
     setImageIfElementExists('album-cover', artwork.value);
-    setAlbumNAmeHint(albumName.value);
+    if (trackCount < 2) {
+        setAlbumNAmeHint("This song is a sinlge");
+    } else {
+        setAlbumNAmeHint(albumName.value)
+    }
 
     if (releaseDate.value) {
         const formattedDate = new Date(releaseDate.value).toLocaleDateString('en-GB', {

--- a/app/static/itunesAPIconfig.js
+++ b/app/static/itunesAPIconfig.js
@@ -91,7 +91,7 @@ function setImageIfElementExists(elementId, imageUrl) {
     }
 }
 
-function setAlbumNAmeHint(albumName) {
+function setAlbumNameHint(albumName) {
     setTextIfElementExists('album-name', albumName || "Unknown album");
 }
 
@@ -101,7 +101,7 @@ async function getAlbumTrackCount(collectionID) {
     }
 
     try {
-        const response = await fetch('/api/album-track-count?collection_id=${collectionID}');
+        const response = await fetch(`/api/album-track-count?collection_id=${collectionID}`);
         const data = await response.json();
 
         return data.trackCount || 0;
@@ -114,7 +114,7 @@ async function getAlbumTrackCount(collectionID) {
 async function GetRandomSong() {
     const res = await fetch('/api/random-song?' + getArtistParams());
     const songDeets = await res.json();
-    const collectionID = songDeets.collectionid;
+    const collectionID = songDeets.collectionId;
     const trackCount = await getAlbumTrackCount(collectionID);
 
     if (songDeets.error) {
@@ -132,12 +132,12 @@ async function GetRandomSong() {
 
     setImageIfElementExists('album-cover', artwork.value);
 
-    const albumTitle = albumNAme.value || "Unknown album";
+    const albumTitle = albumName.value || "Unknown album";
 
     if (trackCount == 1 || albumTitle.toLowerCase().includes("single")) {
-        setAlbumNAmeHint("This song is a sinlge");
+        setAlbumNameHint("This song is a single");
     } else {
-        setAlbumNAmeHint(albumName.value)
+        setAlbumNameHint(albumTitle);
     }
 
     if (releaseDate.value) {

--- a/app/static/itunesAPIconfig.js
+++ b/app/static/itunesAPIconfig.js
@@ -131,7 +131,7 @@ async function GetRandomSong() {
     ]);
 
     setImageIfElementExists('album-cover', artwork.value);
-    if (trackCount < 2) {
+    if (trackCount == 1) {
         setAlbumNAmeHint("This song is a sinlge");
     } else {
         setAlbumNAmeHint(albumName.value)

--- a/app/static/itunesAPIconfig.js
+++ b/app/static/itunesAPIconfig.js
@@ -92,7 +92,7 @@ function setImageIfElementExists(elementId, imageUrl) {
 }
 
 function setAlbumNAmeHint(albumName) {
-    setTextIfElementExists('album-name', albumName || "Unknown album")
+    setTextIfElementExists('album-name', albumName || "Unknown album");
 }
 
 async function getAlbumTrackCount(collectionID) {
@@ -101,7 +101,7 @@ async function getAlbumTrackCount(collectionID) {
     }
 
     try {
-        const response = await fetch ('/api/album-track-count?collection_id=${collectionID}');
+        const response = await fetch('/api/album-track-count?collection_id=${collectionID}');
         const data = await response.json();
 
         return data.trackCount || 0;
@@ -114,7 +114,7 @@ async function getAlbumTrackCount(collectionID) {
 async function GetRandomSong() {
     const res = await fetch('/api/random-song?' + getArtistParams());
     const songDeets = await res.json();
-    const collectionID = songDeets.collectionID
+    const collectionID = songDeets.collectionid;
     const trackCount = await getAlbumTrackCount(collectionID);
 
     if (songDeets.error) {
@@ -131,7 +131,10 @@ async function GetRandomSong() {
     ]);
 
     setImageIfElementExists('album-cover', artwork.value);
-    if (trackCount == 1) {
+
+    const albumTitle = albumNAme.value || "Unknown album";
+
+    if (trackCount == 1 || albumTitle.toLowerCase().includes("single")) {
         setAlbumNAmeHint("This song is a sinlge");
     } else {
         setAlbumNAmeHint(albumName.value)

--- a/app/static/itunesAPIconfig.js
+++ b/app/static/itunesAPIconfig.js
@@ -91,6 +91,9 @@ function setImageIfElementExists(elementId, imageUrl) {
     }
 }
 
+function setAlbumNAmeHint(albumName) {
+    setTextIfElementExists('album-name', albumName || "Unknown album")
+}
 
 async function GetRandomSong() {
     const res = await fetch('/api/random-song?' + getArtistParams());
@@ -110,7 +113,7 @@ async function GetRandomSong() {
     ]);
 
     setImageIfElementExists('album-cover', artwork.value);
-    setTextIfElementExists('album-name', albumName.value || "Unknown album");
+    setAlbumNAmeHint(albumName.value);
 
     if (releaseDate.value) {
         const formattedDate = new Date(releaseDate.value).toLocaleDateString('en-GB', {


### PR DESCRIPTION
Changes in this branch:

- added an API route to count tracks in an iTunes album
- updated the album name hint logic in the main game
- detects when a release only has one track
- detects album titles that include “single”
- shows “This song is a single” instead of revealing the single title as the album name
- tested in the browser using DevTools and confirmed the album hint updates correctly