### PR TITLE
docs: add project run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Spurdle
+
 Spurdle is a music guessing game where you specify your favourite artists and have to guess a random song of theirs based on numerous hints. Guessing with less hints will reward the player with more points, with the highest scoring players being placed on a leaderboard tab so people can interact with others and view their scores.
 
 ## Group Member Information
+
 | UWA ID   | Name                | GitHub Username |
 | -------- | ------------------- | --------------- |
 | 24271659 | Nathan Flack        | nathanjstack    |
@@ -12,6 +14,7 @@ Spurdle is a music guessing game where you specify your favourite artists and ha
 ## Running the Project Locally
 
 ### Prerequisites
+
 - Python 3
 - Git
 - pip
@@ -21,3 +24,25 @@ Spurdle is a music guessing game where you specify your favourite artists and ha
 ```bash
 git clone https://github.com/Mohammadrh84/Spurdle.git
 cd Spurdle
+```
+
+### 2. Create and Activate a Virtual Environment
+
+Create a virtual environment:
+
+```bash
+python -m venv .venv
+```
+
+Activate it on Windows PowerShell:
+
+```bash
+.\.venv\Scripts\Activate.ps1
+```
+
+If PowerShell blocks activation, run:
+
+```bash
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy RemoteSigned
+.\.venv\Scripts\Activate.ps1
+```

--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ Spurdle is a music guessing game where you specify your favourite artists and ha
 - Python 3
 - Git
 - pip
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/Mohammadrh84/Spurdle.git
+cd Spurdle

--- a/README.md
+++ b/README.md
@@ -53,3 +53,16 @@ After activating the virtual environment, install the required Python packages:
 ```bash
 pip install -r requirements.txt
 ```
+
+### 4. Create a `.env` File
+
+Create a file called `.env` in the project root.
+
+Example `.env` file:
+
+```env
+SPURDLE_SECRET_KEY=dev-secret-key
+SPURDLE_DATABASE_URL=sqlite:///game.db
+```
+
+The `.env` file is used to store local configuration values such as the Flask secret key and database URL.

--- a/README.md
+++ b/README.md
@@ -46,3 +46,10 @@ If PowerShell blocks activation, run:
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy RemoteSigned
 .\.venv\Scripts\Activate.ps1
 ```
+### 3. Install Requirements
+
+After activating the virtual environment, install the required Python packages:
+
+```bash
+pip install -r requirements.txt
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spurdle
 
-Spurdle is a music guessing game where you specify your favourite artists and have to guess a random song of theirs based on numerous hints. Guessing with less hints will reward the player with more points, with the highest scoring players being placed on a leaderboard tab so people can interact with others and view their scores.
+Spurdle is a music guessing game where users choose their favourite artists and try to guess a random song using a series of hints. Players receive more points for guessing with fewer hints, and high scores are shown on a leaderboard.
 
 ## Group Member Information
 
@@ -13,7 +13,11 @@ Spurdle is a music guessing game where you specify your favourite artists and ha
 
 ## Running the Project Locally
 
+Follow these steps to run Spurdle on your local machine.
+
 ### Prerequisites
+
+Make sure you have the following installed:
 
 - Python 3
 - Git
@@ -34,7 +38,7 @@ Create a virtual environment:
 python -m venv .venv
 ```
 
-Activate it on Windows PowerShell:
+Activate the virtual environment on Windows PowerShell:
 
 ```bash
 .\.venv\Scripts\Activate.ps1
@@ -46,9 +50,16 @@ If PowerShell blocks activation, run:
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy RemoteSigned
 .\.venv\Scripts\Activate.ps1
 ```
+
+For macOS/Linux, activate the virtual environment with:
+
+```bash
+source .venv/bin/activate
+```
+
 ### 3. Install Requirements
 
-After activating the virtual environment, install the required Python packages:
+Install the required Python packages:
 
 ```bash
 pip install -r requirements.txt
@@ -65,7 +76,7 @@ SPURDLE_SECRET_KEY=dev-secret-key
 SPURDLE_DATABASE_URL=sqlite:///game.db
 ```
 
-The `.env` file is used to store local configuration values such as the Flask secret key and database URL.
+These values are used by the Flask app for local configuration.
 
 ### 5. Set Up the Database
 
@@ -76,6 +87,8 @@ flask --app app db upgrade
 ```
 
 This creates or updates the local database tables needed by the project.
+
+For normal setup, this is the only database migration command needed.
 
 ### 6. Run the Flask App
 
@@ -90,3 +103,4 @@ Then open the local address shown in the terminal, usually:
 ```text
 http://127.0.0.1:5000
 ```
+

--- a/README.md
+++ b/README.md
@@ -76,3 +76,17 @@ flask --app app db upgrade
 ```
 
 This creates or updates the local database tables needed by the project.
+
+### 6. Run the Flask App
+
+Start the Flask development server:
+
+```bash
+flask --app app run
+```
+
+Then open the local address shown in the terminal, usually:
+
+```text
+http://127.0.0.1:5000
+```

--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ Spurdle is a music guessing game where you specify your favourite artists and ha
 | 24364632 | Dhruv Bharuth       | BotDurv         |
 | 24443565 | Mohammad Haddadpour | Mohammadrh84    |
 | 24197094 | Surtaj Singh        | taj-sketch      |
+
+## Running the Project Locally
+
+### Prerequisites
+- Python 3
+- Git
+- pip

--- a/README.md
+++ b/README.md
@@ -66,3 +66,13 @@ SPURDLE_DATABASE_URL=sqlite:///game.db
 ```
 
 The `.env` file is used to store local configuration values such as the Flask secret key and database URL.
+
+### 5. Set Up the Database
+
+Run the database migrations:
+
+```bash
+flask --app app db upgrade
+```
+
+This creates or updates the local database tables needed by the project.


### PR DESCRIPTION
Adds README documentation for running the Spurdle project locally.

Includes:
- prerequisites
- cloning the repository
- creating and activating a virtual environment
- installing requirements
- creating the `.env` file
- running database migrations
- starting the Flask app

Partially addresses #69. Test-running instructions can be added once the test setup is finalised.